### PR TITLE
Removed Travis Email notification

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,8 @@
 dist: trusty
 sudo: false
 language: node_js
+notifications:
+  email: false
 node_js:
   - "7"
 cache: yarn


### PR DESCRIPTION
I just think email build notifications are getting out of control, maybe it would be better to disable them in general